### PR TITLE
Fix bad argument for ProtoField.bytes in WireShark 2.4.0, replace to …

### DIFF
--- a/echonet-lite-data.lua
+++ b/echonet-lite-data.lua
@@ -34,7 +34,7 @@ edata.fields.opc  = ProtoField.uint8("echonetlite.edata.opc", "Property size (OP
 edata.fields.property  = ProtoField.none("echonetlite.edata.property", "Property")
 edata.fields.epc  = ProtoField.uint8("echonetlite.edata.epc", "ECHONET Property (EPC)",  base.HEX)
 edata.fields.pdc  = ProtoField.uint8("echonetlite.edata.pdc", "Property Data Counter (PDC)",  base.DEC)
-edata.fields.edt  = ProtoField.bytes("echonetlite.edata.edt",  "ECHONET Property Value Data (EDT)",  base.HEX)
+edata.fields.edt  = ProtoField.bytes("echonetlite.edata.edt", "ECHONET Property Value Data (EDT)", base.SPACE)
 
 -- ========================================================
 -- Parse ECHONET Lite Data fields.


### PR DESCRIPTION
I got an error when starting WireShark 2.4.0.
Error message
'[String' /Users/someone/.config/wireshark/plugins/ECHONE...": 37: bad argument # 3 to 'bytes' (Display must be either base.NONE, base.DOT, base.DASH, Base.COLON or base.SPACE) "

I replaced the third argument of ProtoField.bytes from base.HEX to base.SPACE.

[API Document](https://www.wireshark.org/docs/wsdg_html_chunked/lua_module_Proto.html#lua_fn_ProtoField_bytes_abbr___name____display____desc__)
